### PR TITLE
Make the game work with modern compilers and fix a crash

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -400,9 +400,7 @@ void Game::draw_score()
 	
 	char text[255];
 	
-	sprintf(text, "%s",("Score: "));
-	
-	sprintf(text, "%s%d", text,(Sint32)m_level->get_current_score());
+	sprintf(text, "Score: %d", (Sint32)m_level->get_current_score());
 	
 	game_font->write(4,real_game_size_y+5, text);
 
@@ -411,8 +409,7 @@ void Game::draw_score()
 
 	if(remaining>0)
 	{
-		sprintf(text,"%s","Remaining:   ");
-		sprintf(text,"%s%d", text, remaining);
+		sprintf(text,"Remaining:   %d", remaining);
 		game_font->write(200,real_game_size_y+5, text);
 
 	}
@@ -498,14 +495,10 @@ void Game::go()
 			m_level=new Level();
   		
 			char current_level_path[255];
-  		
-			sprintf(current_level_path, "%s", (Resource_Factory::instance()->get_resource_path().c_str()));
-  		
-			sprintf(current_level_path, "%s%s", current_level_path, "/maps/level");
-  	
-			sprintf(current_level_path, "%s%d", current_level_path, (menu.get_current_level()));
-  		
-			sprintf(current_level_path, "%s%s", current_level_path, ".map");
+
+			sprintf(current_level_path, "%s/maps/level%d.map",
+			        Resource_Factory::instance()->get_resource_path().c_str(),
+			        menu.get_current_level());
   	
 			DEBOUT("Loading map: "<<current_level_path<<"\n");
   	

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -71,8 +71,9 @@ void Sprite::init(Surface* surf)
 	
 Sprite::~Sprite()
 {
-	delete m_back_replacement;
-	
+	if (m_initialized) {
+		delete m_back_replacement;
+	}
 }
 
 


### PR DESCRIPTION
I experienced a crash on the following conditions:
```
Start first level
Die
Start again -> Crash
```
(Ubuntu 17.10, amd64)

It turned out that the Sprite destructor was trying to delete a Surface even though the Surface had never been set.

In addition I included the patch from https://sources.debian.org/patches/epiphany/0.7.0+0-3/unravel-sprintf.diff/ and expanded it a bit to prevent an undefined behaviour due to a text being printed into itself.